### PR TITLE
Slider range bug fixed

### DIFF
--- a/ZeroOne Flow/View/Common/Slider/RangeSliders.swift
+++ b/ZeroOne Flow/View/Common/Slider/RangeSliders.swift
@@ -25,6 +25,11 @@ struct RangeSliders: View {
                 .lineLimit(1)
                 .minimumScaleFactor(0.1)
         }
+        .onAppear {
+            if range.min > max {
+                range.min = max
+            }
+        }
     }
     
     private var minSlider: some View {
@@ -39,6 +44,11 @@ struct RangeSliders: View {
                 .frame(width: range.min >= 1000 || range.min <= -100 ? 60 : 50)
                 .lineLimit(1)
                 .minimumScaleFactor(0.1)
+        }
+        .onAppear {
+            if range.max < min {
+                range.max = min
+            }
         }
     }
     

--- a/ZeroOne Flow/View/Font/FontRangeView.swift
+++ b/ZeroOne Flow/View/Font/FontRangeView.swift
@@ -10,7 +10,7 @@ struct FontRangeView: View {
     
     var body: some View {
         Section {
-            FontSizeRangeSliders(fontSizeRange: $fonts.sizeRange,
+            FontSizeRangeSliders(range: $fonts.sizeRange,
                                  min: min, max: max)
             FontDesignWeightPicker(fonts: $fonts, isRandom: isRandom)
         } header: {

--- a/ZeroOne Flow/View/Font/FontSizeRangeSliders.swift
+++ b/ZeroOne Flow/View/Font/FontSizeRangeSliders.swift
@@ -3,7 +3,7 @@
 import SwiftUI
 
 struct FontSizeRangeSliders: View {
-    @Binding var fontSizeRange: FontSizeRange
+    @Binding var range: FontSizeRange
     var min: CGFloat
     var max: CGFloat
     
@@ -16,15 +16,20 @@ struct FontSizeRangeSliders: View {
         HStack {
             Text("Max")
                 .font(.title3)
-            Slider(value: $fontSizeRange.max, in: fontSizeRange.min...max)
+            Slider(value: $range.max, in: range.min...max)
                 .padding(.leading, 5)
-            Text(String(format: "%.f", fontSizeRange.max))
+            Text(String(format: "%.f", range.max))
                 .font(.title3)
                 .foregroundColor(.gray)
-                .frame(width: fontSizeRange.max >= 1000
-                       || fontSizeRange.max <= -100 ? 60 : 50)
+                .frame(width: range.max >= 1000
+                       || range.max <= -100 ? 60 : 50)
                 .lineLimit(1)
                 .minimumScaleFactor(0.1)
+        }
+        .onAppear {
+            if range.min > max {
+                range.min = max
+            }
         }
     }
     
@@ -32,15 +37,20 @@ struct FontSizeRangeSliders: View {
         HStack {
             Text("Min")
                 .font(.title3)
-            Slider(value: $fontSizeRange.min, in: min...fontSizeRange.max)
+            Slider(value: $range.min, in: min...range.max)
                 .padding(.leading, 10)
-            Text(String(format: "%.f", fontSizeRange.min))
+            Text(String(format: "%.f", range.min))
                 .font(.title3)
                 .foregroundColor(.gray)
-                .frame(width: fontSizeRange.min >= 1000
-                       || fontSizeRange.min <= -100 ? 60 : 50)
+                .frame(width: range.min >= 1000
+                       || range.min <= -100 ? 60 : 50)
                 .lineLimit(1)
                 .minimumScaleFactor(0.1)
+        }
+        .onAppear {
+            if range.max < min {
+                range.max = min
+            }
         }
     }
 }


### PR DESCRIPTION
When a slider range's max value is smaller than the min, App will crash. Avoid the crash by adjusting the value when the slider appears.